### PR TITLE
Added fields to provide custom XPaths

### DIFF
--- a/packages/playground/src/app/components/playground/playground.component.html
+++ b/packages/playground/src/app/components/playground/playground.component.html
@@ -70,6 +70,27 @@
             </ol>
           </div>
 
+          <div *ngIf="isGenerated">
+            <p>Or enter custom rule:</p>
+            <ng-form (ngSubmit)="applyCustomRule()">
+              <div class="row" style="text-align: left">
+                <div aria-label="Elements XPath (e.g. //body//ul[1]/li)" class="tooltip bottom col-lg-8">
+                  <input [(ngModel)]="customContextXPath" autocomplete="off" autofocus name="context"
+                    style="width: 100%" placeholder="Elements XPath">
+                </div>
+                <div aria-label="Links relative XPath (e.g. ./a[1])" class="tooltip bottom col-lg-8">
+                  <input [(ngModel)]="customLinkXPath" autocomplete="off" name="link" style="width: 100%"
+                    placeholder="Links relative XPath">
+                </div>
+                <div class="col-lg-4">
+                  <a (click)="applyCustomRule()" class="button secondary" href="javascript:void(0)">
+                    Apply
+                  </a>
+                </div>
+              </div>
+            </ng-form>
+          </div>
+
           <div *ngIf="currentRule">
             <p class="wizard_section"><strong>2.</strong> Advanced Settings</p>
             <ul style="list-style: none">

--- a/packages/playground/src/app/components/playground/playground.component.ts
+++ b/packages/playground/src/app/components/playground/playground.component.ts
@@ -50,6 +50,8 @@ export class PlaygroundComponent implements OnInit {
   rules: Array<ArticleRule>;
   currentRule: ArticleRule;
   url: string;
+  customContextXPath: string;
+  customLinkXPath: string;
   showViz = 'viz';
   hasResults = false;
   iframeLoaded = false;
@@ -123,6 +125,20 @@ export class PlaygroundComponent implements OnInit {
     }
   }
 
+  public applyCustomRule() {
+    if (this.isLoading) {
+      return;
+    }
+    const rule: ArticleRule = {
+      hidden: true,
+      linkXPath: this.customLinkXPath,
+      extendContext: 's',
+      contextXPath: this.customContextXPath,
+      id: 'custom',
+    };
+    this.applyRule(rule);
+  }
+
   public getFeedUrl() {
     return this.feedService.getDirectFeedUrl(this.url, this.options);
   }
@@ -146,6 +162,8 @@ export class PlaygroundComponent implements OnInit {
     this.currentRule = null;
     this.logs = [];
     // this.url = null;
+    // this.customContextXPath = '';
+    // this.customLinkXPath = '';
     this.rules = null;
     this.feedData = '';
     if (this.proxyUrl) {


### PR DESCRIPTION
Hi,

I find it useful to be able to provide in the playground custom XPaths in case the suggested rules do not work, or need some tweaking, and see the result immediately.  

Let me know what you think and I hope this edit can make it into your tool!

Thanks,
Thomas